### PR TITLE
fix: Allow usage of MySQL config files by removing --no-defaults flag from MySQL commands where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ specified in wp-config.php.
 Checks the current status of the database.
 
 ~~~
-wp db check [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db check [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--check` using `DB_HOST`,
@@ -181,6 +181,9 @@ for more details on the `CHECK TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db check
@@ -193,7 +196,7 @@ for more details on the `CHECK TABLE` statement.
 Optimizes the database.
 
 ~~~
-wp db optimize [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db optimize [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--optimize=true` using `DB_HOST`,
@@ -214,6 +217,9 @@ for more details on the `OPTIMIZE TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db optimize
@@ -226,7 +232,7 @@ for more details on the `OPTIMIZE TABLE` statement.
 Displays the database table prefix.
 
 ~~~
-wp db prefix 
+wp db prefix
 ~~~
 
 Display the database table prefix, as defined by the database handler's interpretation of the current site.
@@ -243,7 +249,7 @@ Display the database table prefix, as defined by the database handler's interpre
 Repairs the database.
 
 ~~~
-wp db repair [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db repair [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--repair=true` using `DB_HOST`,
@@ -264,6 +270,9 @@ more details on the `REPAIR TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db repair
@@ -276,7 +285,7 @@ more details on the `REPAIR TABLE` statement.
 Opens a MySQL console using credentials from wp-config.php
 
 ~~~
-wp db cli [--database=<database>] [--default-character-set=<character-set>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db cli [--database=<database>] [--default-character-set=<character-set>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 **OPTIONS**
@@ -296,6 +305,9 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--d
 	[--<field>=<value>]
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     # Open MySQL console
@@ -309,7 +321,7 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--d
 Executes a SQL query against the database.
 
 ~~~
-wp db query [<sql>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db query [<sql>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
@@ -328,6 +340,9 @@ Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 
 	[--<field>=<value>]
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 
@@ -366,7 +381,7 @@ Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 Exports the database to a file or to STDOUT.
 
 ~~~
-wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--porcelain]
+wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--porcelain] [--defaults]
 ~~~
 
 Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
@@ -395,6 +410,9 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 
 	[--porcelain]
 		Output filename for the exported database.
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 
@@ -450,7 +468,7 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 Imports a database from a file or from STDIN.
 
 ~~~
-wp db import [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--skip-optimization]
+wp db import [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--skip-optimization] [--defaults]
 ~~~
 
 Runs SQL queries using `DB_HOST`, `DB_NAME`, `DB_USER` and
@@ -474,6 +492,9 @@ defined in the SQL.
 
 	[--skip-optimization]
 		When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ for more details on the `CHECK TABLE` statement.
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -218,7 +218,7 @@ for more details on the `OPTIMIZE TABLE` statement.
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -271,7 +271,7 @@ more details on the `REPAIR TABLE` statement.
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -306,7 +306,7 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--d
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -342,7 +342,7 @@ Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -412,7 +412,7 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 		Output filename for the exported database.
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 
@@ -494,7 +494,7 @@ defined in the SQL.
 		When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
 
 	[--defaults]
-		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+		Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 
 **EXAMPLES**
 

--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -97,3 +97,18 @@ Feature: Check the database
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I try `wp db check --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqlcheck %s
+      """
+
+    When I try `wp db check --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqlcheck --no-defaults %s
+      """

--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -13,6 +13,19 @@ Feature: Check the database
       Success: Database checked.
       """
 
+  Scenario: Run db check with MySQL defaults to check the database
+    Given a WP install
+
+    When I run `wp db check --defaults`
+    Then STDOUT should contain:
+      """
+      wp_cli_test.wp_users
+      """
+    And STDOUT should contain:
+      """
+      Success: Database checked.
+      """
+
   Scenario: Run db check with passed-in options
     Given a WP install
 
@@ -104,11 +117,11 @@ Feature: Check the database
     When I try `wp db check --defaults --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysqlcheck %s
+      Debug (db): Running shell command: /usr/bin/env mysqlcheck %s
       """
 
     When I try `wp db check --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysqlcheck --no-defaults %s
+      Debug (db): Running shell command: /usr/bin/env mysqlcheck --no-defaults %s
       """

--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -98,7 +98,7 @@ Feature: Check the database
       """
     And STDOUT should be empty
 
-  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+  Scenario: MySQL defaults are available as appropriate with --defaults flag
     Given a WP install
 
     When I try `wp db check --defaults --debug`

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -43,6 +43,15 @@ Feature: Export a WordPress database
       -- MySQL dump
       """
 
+  Scenario: Export database with mysql defaults to STDOUT
+    Given a WP install
+
+    When I run `wp db export --defaults -`
+    Then STDOUT should contain:
+      """
+      -- MySQL dump
+      """
+
   Scenario: Export database with passed-in options
     Given a WP install
 
@@ -60,17 +69,17 @@ Feature: Export a WordPress database
       """
     And STDOUT should be empty
 
-  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+  Scenario: MySQL defaults are available as appropriate with --defaults flag
     Given a WP install
 
     When I try `wp db export --defaults --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysqldump
+      Debug (db): Running initial shell command: /usr/bin/env mysqldump
       """
 
     When I try `wp db export --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysqldump --no-defaults
+      Debug (db): Running initial shell command: /usr/bin/env mysqldump --no-defaults
       """

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -59,3 +59,18 @@ Feature: Export a WordPress database
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I try `wp db export --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqldump
+      """
+
+    When I try `wp db export --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqldump --no-defaults
+      """

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -12,6 +12,18 @@ Feature: Import a WordPress database
       Success: Imported from 'wp_cli_test.sql'.
       """
 
+  Scenario: Import from database name path by default with mysql defaults
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I run `wp db import --defaults`
+    Then STDOUT should be:
+      """
+      Success: Imported from 'wp_cli_test.sql'.
+      """
+
   Scenario: Import from STDIN
     Given a WP install
 
@@ -104,7 +116,7 @@ Feature: Import a WordPress database
       """
       wp db import
       """
-  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+  Scenario: MySQL defaults are available as appropriate with --defaults flag
     Given a WP install
 
     When I run `wp db export wp_cli_test.sql`
@@ -113,11 +125,11 @@ Feature: Import a WordPress database
     When I try `wp db import --defaults --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      Debug (db): Running shell command: /usr/bin/env mysql --no-auto-rehash
       """
 
     When I try `wp db import --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
       """

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -104,3 +104,20 @@ Feature: Import a WordPress database
       """
       wp db import
       """
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I try `wp db import --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      """
+
+    When I try `wp db import --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      """

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -38,17 +38,34 @@ Feature: Query the database with WordPress' MySQL config
       """
     And STDOUT should be empty
 
-  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+  Scenario: Database querying with MySQL defaults and passed-in options
+    Given a WP install
+
+    When I run `wp db query --defaults "SELECT COUNT(ID) FROM wp_posts;" --dbuser=wp_cli_test --html`
+    Then STDOUT should contain:
+      """
+      <TABLE
+      """
+
+    When I try `wp db query --defaults "SELECT COUNT(ID) FROM wp_posts;" --dbuser=no_such_user`
+	Then the return code should not be 0
+    And STDERR should contain:
+      """
+      Access denied
+      """
+    And STDOUT should be empty
+
+  Scenario: MySQL defaults are available as appropriate with --defaults flag
     Given a WP install
 
   When I try `wp db query --defaults --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      Debug (db): Running shell command: /usr/bin/env mysql --no-auto-rehash
       """
 
     When I try `wp db query --debug`
     Then STDERR should contain:
       """
-      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      Debug (db): Running shell command: /usr/bin/env mysql --no-defaults --no-auto-rehash
       """

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -37,3 +37,18 @@ Feature: Query the database with WordPress' MySQL config
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+  When I try `wp db query --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      """
+
+    When I try `wp db query --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -1686,7 +1686,7 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative args array.
 	 * @return string Either the '--no-defaults' flag for use in the command or an empty string.
 	 */
-	private static function get_no_defaults( &$assoc_args ) {
+	private static function get_defaults_flag_string( &$assoc_args ) {
 
 		if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
 			unset( $assoc_args['defaults'] );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -198,15 +198,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db check
 	 *     Success: Database checked.
 	 */
 	public function check( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['check'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -234,15 +241,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db optimize
 	 *     Success: Database optimized.
 	 */
 	public function optimize( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['optimize'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -270,15 +284,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db repair
 	 *     Success: Database repaired.
 	 */
 	public function repair( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['repair'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -305,6 +326,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Open MySQL console
@@ -314,11 +338,15 @@ class DB_Command extends WP_CLI_Command {
 	 * @alias connect
 	 */
 	public function cli( $args, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
 		if ( ! isset( $assoc_args['database'] ) ) {
 			$assoc_args['database'] = DB_NAME;
 		}
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $assoc_args );
+		self::run( $command, $assoc_args );
 	}
 
 	/**
@@ -340,6 +368,9 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
+	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -372,6 +403,10 @@ class DB_Command extends WP_CLI_Command {
 	 *     +---+------+------------------------------+-----+
 	 */
 	public function query( $args, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['database'] = DB_NAME;
 
 		// The query might come from STDIN.
@@ -379,7 +414,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $assoc_args );
+		self::run( $command, $assoc_args );
 	}
 
 	/**
@@ -411,6 +446,9 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--porcelain]
 	 * : Output filename for the exported database.
+	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -484,10 +522,13 @@ class DB_Command extends WP_CLI_Command {
 
 		$support_column_statistics = exec( 'mysqldump --help | grep "column-statistics"' );
 
+		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $initial_command, 'db' );
+
 		if ( $support_column_statistics ) {
-			$command = '/usr/bin/env mysqldump --no-defaults --skip-column-statistics %s';
+			$command = $initial_command . '--skip-column-statistics %s';
 		} else {
-			$command = '/usr/bin/env mysqldump --no-defaults %s';
+			$command = $initial_command . '%s';
 		}
 
 		$command_esc_args = array( DB_NAME );
@@ -552,6 +593,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--skip-optimization]
 	 * : When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Import MySQL from a file.
@@ -586,7 +630,10 @@ class DB_Command extends WP_CLI_Command {
 		// Check if any mysql option pass.
 		$mysql_args = array_merge( $mysql_args, self::get_mysql_args( $assoc_args ) );
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $mysql_args );
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
+		self::run( $command, $mysql_args );
 
 		WP_CLI::success( sprintf( "Imported from '%s'.", $result_file ) );
 	}
@@ -1371,7 +1418,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	private static function run_query( $query, $assoc_args = array() ) {
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', array_merge( $assoc_args, array( 'execute' => $query ) ) );
+		self::run( sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) ), array_merge( $assoc_args, array( 'execute' => $query ) ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {
@@ -1631,5 +1678,22 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return $mysql_args;
+	}
+
+	/**
+	 * Writes out the `--no-defaults` flag for MySQL commands unless the --defaults flag is specified for the WP_CLI command.
+	 *
+	 * @param array $assoc_args Associative args array.
+	 * @return string Either the '--no-defaults' flag for use in the command or an empty string.
+	 */
+	private static function get_no_defaults( &$assoc_args ) {
+
+		if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
+			unset( $assoc_args['defaults'] );
+			return '';
+		}
+
+		return ' --no-defaults';
+
 	}
 }

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -49,7 +49,7 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function create( $_, $assoc_args ) {
 
-		self::run_query( self::get_create_query(), self::get_dbuser_dbpass_args( $assoc_args ) );
+		$this->run_query( self::get_create_query(), self::get_dbuser_dbpass_args( $assoc_args ) );
 
 		WP_CLI::success( 'Database created.' );
 	}
@@ -80,7 +80,7 @@ class DB_Command extends WP_CLI_Command {
 	public function drop( $_, $assoc_args ) {
 		WP_CLI::confirm( "Are you sure you want to drop the '" . DB_NAME . "' database?", $assoc_args );
 
-		self::run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ), self::get_dbuser_dbpass_args( $assoc_args ) );
+		$this->run_query( sprintf( 'DROP DATABASE `%s`', DB_NAME ), self::get_dbuser_dbpass_args( $assoc_args ) );
 
 		WP_CLI::success( 'Database dropped.' );
 	}
@@ -113,8 +113,8 @@ class DB_Command extends WP_CLI_Command {
 
 		$mysql_args = self::get_dbuser_dbpass_args( $assoc_args );
 
-		self::run_query( sprintf( 'DROP DATABASE IF EXISTS `%s`', DB_NAME ), $mysql_args );
-		self::run_query( self::get_create_query(), $mysql_args );
+		$this->run_query( sprintf( 'DROP DATABASE IF EXISTS `%s`', DB_NAME ), $mysql_args );
+		$this->run_query( self::get_create_query(), $mysql_args );
 
 		WP_CLI::success( 'Database reset.' );
 	}
@@ -164,7 +164,7 @@ class DB_Command extends WP_CLI_Command {
 		);
 
 		foreach ( $tables as $table ) {
-			self::run_query(
+			$this->run_query(
 				sprintf(
 					'DROP TABLE IF EXISTS `%s`.`%s`',
 					DB_NAME,
@@ -199,7 +199,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -208,7 +208,7 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function check( $_, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
 		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['check'] = true;
@@ -242,7 +242,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -251,8 +251,8 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function optimize( $_, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
-		WP_CLI::debug( $command, 'db' );
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['optimize'] = true;
 		self::run(
@@ -285,7 +285,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -294,8 +294,8 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function repair( $_, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
-		WP_CLI::debug( $command, 'db' );
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', $this->get_defaults_flag_string( $assoc_args ), '%s' );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['repair'] = true;
 		self::run(
@@ -327,7 +327,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -339,8 +339,8 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function cli( $args, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
-		WP_CLI::debug( $command, 'db' );
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		if ( ! isset( $assoc_args['database'] ) ) {
 			$assoc_args['database'] = DB_NAME;
@@ -370,7 +370,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -404,8 +404,8 @@ class DB_Command extends WP_CLI_Command {
 	 */
 	public function query( $args, $assoc_args ) {
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
-		WP_CLI::debug( $command, 'db' );
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['database'] = DB_NAME;
 
@@ -448,7 +448,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : Output filename for the exported database.
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -522,8 +522,8 @@ class DB_Command extends WP_CLI_Command {
 
 		$support_column_statistics = exec( 'mysqldump --help | grep "column-statistics"' );
 
-		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', self::get_no_defaults( $assoc_args ) );
-		WP_CLI::debug( $initial_command, 'db' );
+		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', $this->get_defaults_flag_string( $assoc_args ) );
+		WP_CLI::debug( "Running initial shell command: {$initial_command}", 'db' );
 
 		if ( $support_column_statistics ) {
 			$command = $initial_command . '--skip-column-statistics %s';
@@ -594,7 +594,7 @@ class DB_Command extends WP_CLI_Command {
 	 * : When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
 	 *
 	 * [--defaults]
-	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 * : Loads the environment's MySQL option files. Default behavior is to skip loading them to avoid failures due to misconfiguration.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -630,8 +630,8 @@ class DB_Command extends WP_CLI_Command {
 		// Check if any mysql option pass.
 		$mysql_args = array_merge( $mysql_args, self::get_mysql_args( $assoc_args ) );
 
-		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
-		WP_CLI::debug( $command, 'db' );
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		self::run( $command, $mysql_args );
 
@@ -1417,8 +1417,8 @@ class DB_Command extends WP_CLI_Command {
 		return $create_query;
 	}
 
-	private static function run_query( $query, $assoc_args = array() ) {
-		self::run( sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) ), array_merge( $assoc_args, array( 'execute' => $query ) ) );
+	protected function run_query( $query, $assoc_args = array() ) {
+		self::run( sprintf( '/usr/bin/env mysql%s --no-auto-rehash', $this->get_defaults_flag_string( $assoc_args ) ), array_merge( $assoc_args, array( 'execute' => $query ) ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {
@@ -1686,7 +1686,7 @@ class DB_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative args array.
 	 * @return string Either the '--no-defaults' flag for use in the command or an empty string.
 	 */
-	private static function get_defaults_flag_string( &$assoc_args ) {
+	protected function get_defaults_flag_string( &$assoc_args ) {
 
 		if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
 			unset( $assoc_args['defaults'] );

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -209,7 +209,7 @@ class DB_Command extends WP_CLI_Command {
 	public function check( $_, $assoc_args ) {
 
 		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
-		WP_CLI::debug( $command, 'db' );
+		WP_CLI::debug( "Running shell command: {$command}", 'db' );
 
 		$assoc_args['check'] = true;
 		self::run(


### PR DESCRIPTION
Adds a `--defaults` flag to all wp-cli commands where the `--no-defaults` flag was passed to MySQL. When invoked, the `--defaults` flag will remove the latter flag allowing usage of default my.cnf or other my.cnf files as appropriate.