### PR TITLE
fix: Add usage of --defaults flag to allow loading of MySQL configs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ specified in wp-config.php.
 Checks the current status of the database.
 
 ~~~
-wp db check [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db check [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--check` using `DB_HOST`,
@@ -181,6 +181,9 @@ for more details on the `CHECK TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db check
@@ -193,7 +196,7 @@ for more details on the `CHECK TABLE` statement.
 Optimizes the database.
 
 ~~~
-wp db optimize [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db optimize [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--optimize=true` using `DB_HOST`,
@@ -214,6 +217,9 @@ for more details on the `OPTIMIZE TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db optimize
@@ -226,7 +232,7 @@ for more details on the `OPTIMIZE TABLE` statement.
 Displays the database table prefix.
 
 ~~~
-wp db prefix 
+wp db prefix
 ~~~
 
 Display the database table prefix, as defined by the database handler's interpretation of the current site.
@@ -243,7 +249,7 @@ Display the database table prefix, as defined by the database handler's interpre
 Repairs the database.
 
 ~~~
-wp db repair [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db repair [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Runs `mysqlcheck` utility with `--repair=true` using `DB_HOST`,
@@ -264,6 +270,9 @@ more details on the `REPAIR TABLE` statement.
 	[--<field>=<value>]
 		Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     $ wp db repair
@@ -276,7 +285,7 @@ more details on the `REPAIR TABLE` statement.
 Opens a MySQL console using credentials from wp-config.php
 
 ~~~
-wp db cli [--database=<database>] [--default-character-set=<character-set>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db cli [--database=<database>] [--default-character-set=<character-set>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 **OPTIONS**
@@ -296,6 +305,9 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--d
 	[--<field>=<value>]
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+
 **EXAMPLES**
 
     # Open MySQL console
@@ -309,7 +321,7 @@ wp db cli [--database=<database>] [--default-character-set=<character-set>] [--d
 Executes a SQL query against the database.
 
 ~~~
-wp db query [<sql>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>]
+wp db query [<sql>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--defaults]
 ~~~
 
 Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
@@ -328,6 +340,9 @@ Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 
 	[--<field>=<value>]
 		Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 
@@ -366,7 +381,7 @@ Executes an arbitrary SQL query using `DB_HOST`, `DB_NAME`, `DB_USER`
 Exports the database to a file or to STDOUT.
 
 ~~~
-wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--porcelain]
+wp db export [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--tables=<tables>] [--exclude_tables=<tables>] [--porcelain] [--defaults]
 ~~~
 
 Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
@@ -395,6 +410,9 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 
 	[--porcelain]
 		Output filename for the exported database.
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 
@@ -450,7 +468,7 @@ Runs `mysqldump` utility using `DB_HOST`, `DB_NAME`, `DB_USER` and
 Imports a database from a file or from STDIN.
 
 ~~~
-wp db import [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--skip-optimization]
+wp db import [<file>] [--dbuser=<value>] [--dbpass=<value>] [--<field>=<value>] [--skip-optimization] [--defaults]
 ~~~
 
 Runs SQL queries using `DB_HOST`, `DB_NAME`, `DB_USER` and
@@ -474,6 +492,9 @@ defined in the SQL.
 
 	[--skip-optimization]
 		When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
+
+	[--defaults]
+		Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 
 **EXAMPLES**
 

--- a/features/db-check.feature
+++ b/features/db-check.feature
@@ -97,3 +97,18 @@ Feature: Check the database
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I try `wp db check --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqlcheck %s
+      """
+
+    When I try `wp db check --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqlcheck --no-defaults %s
+      """

--- a/features/db-export.feature
+++ b/features/db-export.feature
@@ -59,3 +59,18 @@ Feature: Export a WordPress database
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I try `wp db export --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqldump
+      """
+
+    When I try `wp db export --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysqldump --no-defaults
+      """

--- a/features/db-import.feature
+++ b/features/db-import.feature
@@ -104,3 +104,20 @@ Feature: Import a WordPress database
       """
       wp db import
       """
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+    When I run `wp db export wp_cli_test.sql`
+    Then the wp_cli_test.sql file should exist
+
+    When I try `wp db import --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      """
+
+    When I try `wp db import --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      """

--- a/features/db-query.feature
+++ b/features/db-query.feature
@@ -37,3 +37,18 @@ Feature: Query the database with WordPress' MySQL config
       Access denied
       """
     And STDOUT should be empty
+
+  Scenario: Ensure MySQL defaults are available when as appropriate with --defaults flag
+    Given a WP install
+
+  When I try `wp db query --defaults --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-auto-rehash
+      """
+
+    When I try `wp db query --debug`
+    Then STDERR should contain:
+      """
+      Debug (db): /usr/bin/env mysql --no-defaults --no-auto-rehash
+      """

--- a/src/DB_Command.php
+++ b/src/DB_Command.php
@@ -198,15 +198,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db check
 	 *     Success: Database checked.
 	 */
 	public function check( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['check'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -234,15 +241,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db optimize
 	 *     Success: Database optimized.
 	 */
 	public function optimize( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['optimize'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -270,15 +284,22 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysqlcheck. [Refer to mysqlcheck docs](https://dev.mysql.com/doc/en/mysqlcheck.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     $ wp db repair
 	 *     Success: Database repaired.
 	 */
 	public function repair( $_, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysqlcheck%s %s', self::get_no_defaults( $assoc_args ), '%s' );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['repair'] = true;
 		self::run(
-			Utils\esc_cmd( '/usr/bin/env mysqlcheck --no-defaults %s', DB_NAME ),
+			Utils\esc_cmd( $command, DB_NAME ),
 			$assoc_args
 		);
 
@@ -305,6 +326,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Open MySQL console
@@ -314,11 +338,15 @@ class DB_Command extends WP_CLI_Command {
 	 * @alias connect
 	 */
 	public function cli( $args, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
 		if ( ! isset( $assoc_args['database'] ) ) {
 			$assoc_args['database'] = DB_NAME;
 		}
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $assoc_args );
+		self::run( $command, $assoc_args );
 	}
 
 	/**
@@ -340,6 +368,9 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--<field>=<value>]
 	 * : Extra arguments to pass to mysql. [Refer to mysql docs](https://dev.mysql.com/doc/en/mysql-command-options.html).
+	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -372,6 +403,10 @@ class DB_Command extends WP_CLI_Command {
 	 *     +---+------+------------------------------+-----+
 	 */
 	public function query( $args, $assoc_args ) {
+
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
 		$assoc_args['database'] = DB_NAME;
 
 		// The query might come from STDIN.
@@ -379,7 +414,7 @@ class DB_Command extends WP_CLI_Command {
 			$assoc_args['execute'] = $args[0];
 		}
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $assoc_args );
+		self::run( $command, $assoc_args );
 	}
 
 	/**
@@ -411,6 +446,9 @@ class DB_Command extends WP_CLI_Command {
 	 *
 	 * [--porcelain]
 	 * : Output filename for the exported database.
+	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -484,10 +522,13 @@ class DB_Command extends WP_CLI_Command {
 
 		$support_column_statistics = exec( 'mysqldump --help | grep "column-statistics"' );
 
+		$initial_command = sprintf( '/usr/bin/env mysqldump%s ', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $initial_command, 'db' );
+
 		if ( $support_column_statistics ) {
-			$command = '/usr/bin/env mysqldump --no-defaults --skip-column-statistics %s';
+			$command = $initial_command . '--skip-column-statistics %s';
 		} else {
-			$command = '/usr/bin/env mysqldump --no-defaults %s';
+			$command = $initial_command . '%s';
 		}
 
 		$command_esc_args = array( DB_NAME );
@@ -552,6 +593,9 @@ class DB_Command extends WP_CLI_Command {
 	 * [--skip-optimization]
 	 * : When using an SQL file, do not include speed optimization such as disabling auto-commit and key checks.
 	 *
+	 * [--defaults]
+	 * : Removes the "--no-defaults" flag normally passed to MySQL allowing it to use the default my.cnf or one specified with the MYSQL_HOME environment variable.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     # Import MySQL from a file.
@@ -586,7 +630,10 @@ class DB_Command extends WP_CLI_Command {
 		// Check if any mysql option pass.
 		$mysql_args = array_merge( $mysql_args, self::get_mysql_args( $assoc_args ) );
 
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', $mysql_args );
+		$command = sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) );
+		WP_CLI::debug( $command, 'db' );
+
+		self::run( $command, $mysql_args );
 
 		WP_CLI::success( sprintf( "Imported from '%s'.", $result_file ) );
 	}
@@ -1371,7 +1418,7 @@ class DB_Command extends WP_CLI_Command {
 	}
 
 	private static function run_query( $query, $assoc_args = array() ) {
-		self::run( '/usr/bin/env mysql --no-defaults --no-auto-rehash', array_merge( $assoc_args, array( 'execute' => $query ) ) );
+		self::run( sprintf( '/usr/bin/env mysql%s --no-auto-rehash', self::get_no_defaults( $assoc_args ) ), array_merge( $assoc_args, array( 'execute' => $query ) ) );
 	}
 
 	private static function run( $cmd, $assoc_args = array(), $descriptors = null ) {
@@ -1631,5 +1678,22 @@ class DB_Command extends WP_CLI_Command {
 		}
 
 		return $mysql_args;
+	}
+
+	/**
+	 * Writes out the `--no-defaults` flag for MySQL commands unless the --defaults flag is specified for the WP_CLI command.
+	 *
+	 * @param array $assoc_args Associative args array.
+	 * @return string Either the '--no-defaults' flag for use in the command or an empty string.
+	 */
+	private static function get_no_defaults( &$assoc_args ) {
+
+		if ( true === Utils\get_flag_value( $assoc_args, 'defaults' ) ) {
+			unset( $assoc_args['defaults'] );
+			return '';
+		}
+
+		return ' --no-defaults';
+
 	}
 }


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

Please review our contributing guidelines if you haven't recently: https://make.wordpress.org/cli/handbook/contributing/#creating-a-pull-request

Here's an overview to our process:

1. One of the project committers will soon provide a code review: https://make.wordpress.org/cli/handbook/code-review/
2. You are expected to address the code review comments in a timely manner (if we don't hear from you in two weeks, we'll consider your pull request abandoned).
3. Please make sure to include functional tests for your changes.
4. The reviewing committer will merge your pull request as soon as it passes code review (and provided it fits within the scope of the project).

You can safely delete this comment.

-->
